### PR TITLE
LogIterator: Change property modifiers from `private` to `protected`

### DIFF
--- a/src/LogIterator.php
+++ b/src/LogIterator.php
@@ -20,27 +20,27 @@ class LogIterator implements \Iterator
     /**
      * @var LineParserInterface
      */
-    private $parser;
+    protected $parser;
 
     /**
      * @var string
      */
-    private $logFile;
+    protected $logFile;
 
     /**
      * @var resource
      */
-    private $fileHandler;
+    protected $fileHandler;
 
     /**
      * @var string
      */
-    private $currentLine;
+    protected $currentLine;
 
     /**
      * @var bool
      */
-    private $skipEmptyLines;
+    protected $skipEmptyLines;
 
     /**
      * Constructor.


### PR DESCRIPTION
I am working on a `LogIterator` for `.gz` files. Changing `LogIterator` property modifiers from `private` to `protected` helps creating subclasses.